### PR TITLE
Added "six" to the pip install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,7 +28,7 @@ fi
 
 echo "installing pip packages"
 # we install more than we strictly need here, because pip is so easy
-sudo $PIP install --upgrade html flask-socketio pillow pyelftools socketIO-client pydot ipaddr capstone ./qiradb
+sudo $PIP install --upgrade six html flask-socketio pillow pyelftools socketIO-client pydot ipaddr capstone ./qiradb
 
 echo "making symlink"
 sudo ln -sf $(pwd)/qira /usr/local/bin/qira


### PR DESCRIPTION
I had a bug during installation: "'module' object has no attribute 'PY2'". Making sure "six" module is up to date should solve this. 
See: http://stackoverflow.com/questions/24081043/module-object-has-no-attribute-py2
