### PR TITLE
Add capstone backend

### DIFF
--- a/middleware/qira.py
+++ b/middleware/qira.py
@@ -28,6 +28,8 @@ if __name__ == '__main__':
   parser.add_argument("--host", metavar="HOST", help="listen address for web interface and socat. 127.0.0.1 by default", default=qira_config.HOST)
   parser.add_argument("--web-port", metavar="PORT", help="listen port for web interface. 3002 by default", type=int, default=qira_config.WEB_PORT)
   parser.add_argument("--socat-port", metavar="PORT", help="listen port for socat. 4000 by default", type=int, default=qira_config.SOCAT_PORT)
+  #parser.add_argument("--with-capstone", metavar="WITH_CAPSTONE", help="enable capstone for smarter disassembly", action="store_true")
+  #capstone flag in qira_config for now
 
   # parse arguments, first try
   args, unknown = parser.parse_known_args()
@@ -58,6 +60,12 @@ if __name__ == '__main__':
   qira_config.WEB_PORT = args.web_port
   qira_config.SOCAT_PORT = args.socat_port
   qira_config.FORK_PORT = args.socat_port + 1
+  if qira_config.WITH_CAPSTONE:
+    try:
+      from capstone import *
+    except:
+      print "*** warning: WITH_CAPSTONE enabled but capstone not installed."
+      qira_config.WITH_CAPSTONE = False
   if sys.platform == "darwin":
     print "*** running on darwin, defaulting to --pin"
     qira_config.USE_PIN = True

--- a/middleware/qira_config.py
+++ b/middleware/qira_config.py
@@ -21,5 +21,6 @@ CALLED_AS_CDA = False
 
 # turn this off for now on releases
 WITH_STATIC = False
+WITH_CAPSTONE = True
 
 

--- a/middleware/qira_webserver.py
+++ b/middleware/qira_webserver.py
@@ -288,15 +288,17 @@ def getinstructions(forknum, clnum, clstart, clend):
 
     #ned: always use program.disasm if possible for smarter
     #representation of instruction
-    try:
-      # use the memory
-      rawins = trace.fetch_memory(i, rret['address'], rret['data'])
-      if len(rawins) == rret['data']:
-        raw = ''.join(map(lambda x: chr(x[1]), sorted(rawins.items())))
-        insdata = program.disasm(raw, rret['address'])
-    except Exception,e:
-      print "something failed, :(",e
-      # fetch the instruction from the qemu dump
+    if qira_config.WITH_CAPSTONE or 'instruction' not in program.tags[rret['address']]:
+      try:
+        # use the memory
+        rawins = trace.fetch_memory(i, rret['address'], rret['data'])
+        if len(rawins) == rret['data']:
+          raw = ''.join(map(lambda x: chr(x[1]), sorted(rawins.items())))
+          insdata = program.disasm(raw, rret['address'])
+      except Exception,e:
+        # fetch the instruction from the qemu dump
+        insdata = {"repr": program.tags[rret['address']]['instruction']}
+    else:
       insdata = {"repr": program.tags[rret['address']]['instruction']}
 
     #if the capstone disas succeeded, besides repr we'll have:


### PR DESCRIPTION
I've added/extended capstone as a backend to actually disassemble instructions for all of the existing architectures rather than pull strings out of the qemu dump (not that capstone is smarter than QEMU in this regard, but we'll be able to get a "smarter" instruction representation on the frontend)

The frontend has the exact same behavior until we discuss what behavior you want wrt registers/instructions.

After that the next stage will be to use capstone to disassemble not just memory from the traces but instructions out of the original binary for the static portion of QIRA. (in case instructions were missed)
