### PR TITLE
Fixed ARM Thumb

### DIFF
--- a/middleware/qira_config.py
+++ b/middleware/qira_config.py
@@ -23,5 +23,6 @@ CALLED_AS_CDA = False
 # turn this off for now on releases
 WITH_STATIC = False
 WITH_CAPSTONE = False
+
 WITH_IDA = False
 

--- a/middleware/qira_program.py
+++ b/middleware/qira_program.py
@@ -267,8 +267,8 @@ class Program:
         continue
       #print repr(d)
       if self.fb == 0x28:   # ARM
-        inst = d[d.rfind("  ")+2:-1] #last bit now the thumb bit
-        thumb_flag = d[-1]
+        inst = d[d.rfind("  ")+2] #last bit now the thumb bit
+        thumb_flag = d[0]
         if thumb_flag == 't':
           thumb = True
         elif thumb_flag == 'n':

--- a/qemu_mods/disas.c
+++ b/qemu_mods/disas.c
@@ -309,6 +309,10 @@ void real_target_disas(FILE *out, CPUArchState *env, target_ulong code,
     }
 
     for (pc = code; size > 0; pc += count, size -= count) {
+    #ifdef TARGET_ARM
+    if (flags & 1) fprintf(out, "t");
+    else fprintf(out, "n");
+    #endif
 	fprintf(out, "0x" TARGET_FMT_lx ":  ", pc);
 	count = print_insn(pc, &s.info);
 #if 0
@@ -323,10 +327,6 @@ void real_target_disas(FILE *out, CPUArchState *env, target_ulong code,
             fprintf(out, " }");
         }
 #endif
-  #ifdef TARGET_ARM
-  if (flags & 1) fprintf(out, "t");
-  else fprintf(out, "n");
-  #endif
 	fprintf(out, "\n");
 	if (count < 0)
 	    break;

--- a/qiradb/qiradb/Trace.cpp
+++ b/qiradb/qiradb/Trace.cpp
@@ -57,11 +57,6 @@ Trace::~Trace() {
 char Trace::get_type_from_flags(uint32_t flags) {
   if (!(flags & IS_VALID)) return '?';
   if (flags & IS_START) return 'I';
-  /*
-  if (flags & IS_START) {
-    if (flags & IS_THUMB) return 'T'; // IS_THUMB implies IS_START
-    else return 'I';
-  */
   if (flags & IS_SYSCALL) return 's';
 
   if (flags & IS_MEM) {

--- a/qiradb/qiradb/Trace.h
+++ b/qiradb/qiradb/Trace.h
@@ -85,7 +85,6 @@ struct change {
 #define IS_MEM        0x20000000
 #define IS_START      0x10000000
 #define IS_SYSCALL    0x08000000
-//#define IS_THUMB      0x04000000
 #define SIZE_MASK     0xFF
 
 #define PAGE_INSTRUCTION 1


### PR DESCRIPTION
Hope I didn't break something else. I tested on more stuff under tests/ this time. ARM code that's a mix of thumb and normal instructions seems to work.

I add a "t" or "n" character to the end of instructions that are ARM in qira_asm then read that. Hacky, but meets the new version >= old version criteria for pushing.
