### PR TITLE
x86_64 should just work as it is in the same group as x86

### DIFF
--- a/static2/recursive.py
+++ b/static2/recursive.py
@@ -33,8 +33,8 @@ class Block:
 # runs the recursive descent parser at address
 # how to deal with block groupings?
 def make_function_at(self, address, recurse = True):
-  if self['arch'] != "i386":
-    print "*** static only works with x86, someone should fix it"
+  if self['arch'] != "i386" and self['arch'] != "x86-64":
+    print "*** static only works with x86(_64), someone should fix it"
     return
   block_starts = set([address])
   function_starts = set()


### PR DESCRIPTION
x86_64 seems to work on my system (basic blocks/graph layout). That's consistent with the fact that the "x86-specific" code for Capstone has both x86 and x86_64 in the same group. If the only thing we need for static support for other architectures is modifications to the disasm.py, I'd be happy to go ahead and implement them.
