### PR TITLE
Make model.py less X86-specific

### DIFF
--- a/static2/model.py
+++ b/static2/model.py
@@ -1,4 +1,5 @@
 from capstone import *
+import capstone # for some unexported (yet) symbols in Capstone 3.0
 
 __all__ = ["Tags", "Function", "Block", "Instruction", "DESTTYPE"]
 
@@ -38,12 +39,11 @@ class Instruction(object):
       self.regs_write = self.i.regs_write
 
       self.dtype = DESTTYPE.none
-      if self.i.mnemonic == "call":
+      if self.i.mnemonic == "call":  # TODO: this is x86 specific
         self.dtype = DESTTYPE.call
-      elif self.i.mnemonic == "jmp":
+      elif self.i.mnemonic == "jmp": # TODO: this is x86 specific
         self.dtype = DESTTYPE.jump
-      #TODO: what about not x86?
-      elif x86.X86_GRP_JUMP in self.i.groups:
+      elif capstone.CS_GRP_JUMP in self.i.groups:
         self.dtype = DESTTYPE.cjump
 
     #if capstone can't decode it, we're screwed
@@ -68,7 +68,7 @@ class Instruction(object):
       return False
     return self.i.mnemonic == "ret"
     #TODO: what about iret? and RET isn't in the apt version of capstone
-    return x86.X86_GRP_RET in self.i.groups
+    return capstone.CS_GRP_RET in self.i.groups
 
   def is_call(self):
     if not self.decoded:
@@ -79,13 +79,13 @@ class Instruction(object):
     '''is this something which should end a basic block'''
     if not self.decoded:
       return False
-    return self.is_jump() or self.is_ret() or self.i.mnemonic == "hlt"
+    return self.is_jump() or self.is_ret() or self.i.mnemonic == "hlt"  # TODO: this is x86 specific
 
   def is_conditional(self):
     if not self.decoded:
       return False
     #TODO shouldn't be x86 specific
-    return x86.X86_REG_EFLAGS in self.regs_read
+    return x86.X86_REG_EFLAGS in self.regs_read  # TODO: this is x86 specific
 
   def code_follows(self):
     '''should the data after this instructino be treated as code
@@ -111,7 +111,7 @@ class Instruction(object):
     if self.is_jump() or self.is_call():
       #if we take a PTR and not a MEM or REG operand (TODO: better support for MEM operands)
       #TODO: shouldn't be x86 specific
-      if (self.i.operands[0].type == x86.X86_OP_IMM):
+      if (self.i.operands[0].type == capstone.CS_OP_IMM):
         dl.append((self.i.operands[0].value.imm,self.dtype)) #the target of the jump/call
 
     return dl


### PR DESCRIPTION
Capstone 3.0 has been released & introduced some generic operand types & groups. This patch takes advantages of these new features to make "model.py" less X86-specific.
