### PR TITLE
Fix for python dependecies and qemu 2.5.1 with new glibc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pip
 six
 html
-flask-socketio
+flask-socketio==2.9.1
 pillow
 pyelftools
 socketIO-client

--- a/tracers/qemu.patch
+++ b/tracers/qemu.patch
@@ -1,6 +1,6 @@
-diff -ruN qemu-2.5.1/disas.c qemu-2.5.1-patched/disas.c
---- qemu-2.5.1/disas.c	2016-03-29 22:01:14.000000000 +0100
-+++ qemu-2.5.1-patched/disas.c	2016-03-30 16:48:08.429754903 +0100
+diff -Naur qemu-2.5.1/disas.c qemu-2.5.1_patched/disas.c
+--- qemu-2.5.1/disas.c	2016-03-29 23:01:14.000000000 +0200
++++ qemu-2.5.1_patched/disas.c	2017-09-29 18:14:07.249305025 +0200
 @@ -172,6 +172,7 @@
      return print_insn_objdump(pc, info, "OBJD-T");
  }
@@ -38,9 +38,9 @@ diff -ruN qemu-2.5.1/disas.c qemu-2.5.1-patched/disas.c
  	fprintf(out, "0x" TARGET_FMT_lx ":  ", pc);
  	count = s.info.print_insn(pc, &s.info);
  #if 0
-diff -ruN qemu-2.5.1/include/librarymap.h qemu-2.5.1-patched/include/librarymap.h
+diff -Naur qemu-2.5.1/include/librarymap.h qemu-2.5.1_patched/include/librarymap.h
 --- qemu-2.5.1/include/librarymap.h	1970-01-01 01:00:00.000000000 +0100
-+++ qemu-2.5.1-patched/include/librarymap.h	2016-03-30 16:45:38.821919080 +0100
++++ qemu-2.5.1_patched/include/librarymap.h	2017-09-29 18:14:07.249305025 +0200
 @@ -0,0 +1,38 @@
 +struct librarymap {
 +  struct librarymap *next;
@@ -80,9 +80,9 @@ diff -ruN qemu-2.5.1/include/librarymap.h qemu-2.5.1-patched/include/librarymap.
 +  }
 +  return false;
 +}
-diff -ruN qemu-2.5.1/linux-user/elfload.c qemu-2.5.1-patched/linux-user/elfload.c
---- qemu-2.5.1/linux-user/elfload.c	2016-03-29 22:01:17.000000000 +0100
-+++ qemu-2.5.1-patched/linux-user/elfload.c	2016-03-30 16:45:38.821919080 +0100
+diff -Naur qemu-2.5.1/linux-user/elfload.c qemu-2.5.1_patched/linux-user/elfload.c
+--- qemu-2.5.1/linux-user/elfload.c	2016-03-29 23:01:17.000000000 +0200
++++ qemu-2.5.1_patched/linux-user/elfload.c	2017-09-29 18:14:07.249305025 +0200
 @@ -1808,6 +1808,9 @@
  
     On return: INFO values will be filled in, as necessary or available.  */
@@ -106,9 +106,9 @@ diff -ruN qemu-2.5.1/linux-user/elfload.c qemu-2.5.1-patched/linux-user/elfload.
          if (load_addr == -1) {
              goto exit_perror;
          }
-diff -ruN qemu-2.5.1/linux-user/main.c qemu-2.5.1-patched/linux-user/main.c
---- qemu-2.5.1/linux-user/main.c	2016-03-29 22:01:17.000000000 +0100
-+++ qemu-2.5.1-patched/linux-user/main.c	2016-03-30 17:39:36.487105911 +0100
+diff -Naur qemu-2.5.1/linux-user/main.c qemu-2.5.1_patched/linux-user/main.c
+--- qemu-2.5.1/linux-user/main.c	2016-03-29 23:01:17.000000000 +0200
++++ qemu-2.5.1_patched/linux-user/main.c	2017-09-29 18:14:07.249305025 +0200
 @@ -37,7 +37,7 @@
  char *exec_path;
  
@@ -168,9 +168,9 @@ diff -ruN qemu-2.5.1/linux-user/main.c qemu-2.5.1-patched/linux-user/main.c
      {"strace",     "QEMU_STRACE",      false, handle_arg_strace,
       "",           "log system calls"},
      {"seed",       "QEMU_RAND_SEED",   true,  handle_arg_randseed,
-diff -ruN qemu-2.5.1/linux-user/qemu.h qemu-2.5.1-patched/linux-user/qemu.h
---- qemu-2.5.1/linux-user/qemu.h	2016-03-29 22:01:17.000000000 +0100
-+++ qemu-2.5.1-patched/linux-user/qemu.h	2016-03-30 16:45:38.821919080 +0100
+diff -Naur qemu-2.5.1/linux-user/qemu.h qemu-2.5.1_patched/linux-user/qemu.h
+--- qemu-2.5.1/linux-user/qemu.h	2016-03-29 23:01:17.000000000 +0200
++++ qemu-2.5.1_patched/linux-user/qemu.h	2017-09-29 18:14:07.249305025 +0200
 @@ -22,6 +22,8 @@
  
  #define THREAD __thread
@@ -239,9 +239,57 @@ diff -ruN qemu-2.5.1/linux-user/qemu.h qemu-2.5.1-patched/linux-user/qemu.h
  
  #ifdef DEBUG_REMAP
      if (!host_ptr)
-diff -ruN qemu-2.5.1/linux-user/strace.c qemu-2.5.1-patched/linux-user/strace.c
---- qemu-2.5.1/linux-user/strace.c	2016-03-29 22:01:17.000000000 +0100
-+++ qemu-2.5.1-patched/linux-user/strace.c	2016-03-30 16:45:38.821919080 +0100
+diff -Naur qemu-2.5.1/linux-user/signal.c qemu-2.5.1_patched/linux-user/signal.c
+--- qemu-2.5.1/linux-user/signal.c	2016-03-29 23:01:17.000000000 +0200
++++ qemu-2.5.1_patched/linux-user/signal.c	2017-09-29 18:17:46.776194153 +0200
+@@ -3023,7 +3023,7 @@
+     *
+     *   a0 = signal number
+     *   a1 = pointer to siginfo_t
+-    *   a2 = pointer to struct ucontext
++    *   a2 = pointer to ucontext_t
+     *
+     * $25 and PC point to the signal handler, $29 points to the
+     * struct sigframe.
+@@ -3416,7 +3416,7 @@
+ 
+ struct rt_signal_frame {
+     siginfo_t info;
+-    struct ucontext uc;
++    ucontext_t uc;
+     uint32_t tramp[2];
+ };
+ 
+@@ -3627,7 +3627,7 @@
+         siginfo_t *pinfo;
+         void *puc;
+         siginfo_t info;
+-        struct ucontext uc;
++        ucontext_t uc;
+         uint16_t retcode[4];      /* Trampoline code. */
+ };
+ 
+@@ -3924,7 +3924,7 @@
+         tswap_siginfo(&frame->info, info);
+     }
+ 
+-    /*err |= __clear_user(&frame->uc, offsetof(struct ucontext, uc_mcontext));*/
++    /*err |= __clear_user(&frame->uc, offsetof(ucontext_t, uc_mcontext));*/
+     __put_user(0, &frame->uc.tuc_flags);
+     __put_user(0, &frame->uc.tuc_link);
+     __put_user(target_sigaltstack_used.ss_sp,
+@@ -4406,7 +4406,7 @@
+ 
+ struct target_ucontext {
+     target_ulong tuc_flags;
+-    target_ulong tuc_link;    /* struct ucontext __user * */
++    target_ulong tuc_link;    /* ucontext_t __user * */
+     struct target_sigaltstack tuc_stack;
+ #if !defined(TARGET_PPC64)
+     int32_t tuc_pad[7];
+diff -Naur qemu-2.5.1/linux-user/strace.c qemu-2.5.1_patched/linux-user/strace.c
+--- qemu-2.5.1/linux-user/strace.c	2016-03-29 23:01:17.000000000 +0200
++++ qemu-2.5.1_patched/linux-user/strace.c	2017-09-29 18:14:07.249305025 +0200
 @@ -11,6 +11,16 @@
  #include <sched.h>
  #include "qemu.h"
@@ -290,9 +338,9 @@ diff -ruN qemu-2.5.1/linux-user/strace.c qemu-2.5.1-patched/linux-user/strace.c
      gemu_log("%d ", getpid() );
  
      for(i=0;i<nsyscalls;i++)
-diff -ruN qemu-2.5.1/linux-user/strace.list qemu-2.5.1-patched/linux-user/strace.list
---- qemu-2.5.1/linux-user/strace.list	2016-03-29 22:01:17.000000000 +0100
-+++ qemu-2.5.1-patched/linux-user/strace.list	2016-03-30 16:45:38.821919080 +0100
+diff -Naur qemu-2.5.1/linux-user/strace.list qemu-2.5.1_patched/linux-user/strace.list
+--- qemu-2.5.1/linux-user/strace.list	2016-03-29 23:01:17.000000000 +0200
++++ qemu-2.5.1_patched/linux-user/strace.list	2017-09-29 18:14:07.252638364 +0200
 @@ -1000,7 +1000,7 @@
  { TARGET_NR_quotactl, "quotactl" , NULL, NULL, NULL },
  #endif
@@ -311,9 +359,9 @@ diff -ruN qemu-2.5.1/linux-user/strace.list qemu-2.5.1-patched/linux-user/strace
  #endif
  #ifdef TARGET_NR_writev
  { TARGET_NR_writev, "writev" , "%s(%d,%p,%#x)", NULL, NULL },
-diff -ruN qemu-2.5.1/linux-user/syscall.c qemu-2.5.1-patched/linux-user/syscall.c
---- qemu-2.5.1/linux-user/syscall.c	2016-03-29 22:01:17.000000000 +0100
-+++ qemu-2.5.1-patched/linux-user/syscall.c	2016-03-30 16:45:38.821919080 +0100
+diff -Naur qemu-2.5.1/linux-user/syscall.c qemu-2.5.1_patched/linux-user/syscall.c
+--- qemu-2.5.1/linux-user/syscall.c	2016-03-29 23:01:17.000000000 +0200
++++ qemu-2.5.1_patched/linux-user/syscall.c	2017-09-29 18:14:07.252638364 +0200
 @@ -5663,6 +5663,8 @@
      return timerid;
  }
@@ -348,9 +396,9 @@ diff -ruN qemu-2.5.1/linux-user/syscall.c qemu-2.5.1-patched/linux-user/syscall.
      return ret;
  efault:
      ret = -TARGET_EFAULT;
-diff -ruN qemu-2.5.1/tci.c qemu-2.5.1-patched/tci.c
---- qemu-2.5.1/tci.c	2016-03-29 22:01:20.000000000 +0100
-+++ qemu-2.5.1-patched/tci.c	2016-03-30 17:39:24.918794988 +0100
+diff -Naur qemu-2.5.1/tci.c qemu-2.5.1_patched/tci.c
+--- qemu-2.5.1/tci.c	2016-03-29 23:01:20.000000000 +0200
++++ qemu-2.5.1_patched/tci.c	2017-09-29 18:14:07.252638364 +0200
 @@ -28,6 +28,7 @@
  #include "exec/exec-all.h"           /* MAX_OPC_PARAM_IARGS */
  #include "exec/cpu_ldst.h"
@@ -1150,3 +1198,144 @@ diff -ruN qemu-2.5.1/tci.c qemu-2.5.1-patched/tci.c
      return next_tb;
  }
 +
+diff -Naur qemu-2.5.1/tests/tcg/test-i386.c qemu-2.5.1_patched/tests/tcg/test-i386.c
+--- qemu-2.5.1/tests/tcg/test-i386.c	2016-03-29 23:01:22.000000000 +0200
++++ qemu-2.5.1_patched/tests/tcg/test-i386.c	2017-09-29 18:17:12.402832064 +0200
+@@ -1720,7 +1720,7 @@
+ 
+ void sig_handler(int sig, siginfo_t *info, void *puc)
+ {
+-    struct ucontext *uc = puc;
++    ucontext_t *uc = puc;
+ 
+     printf("si_signo=%d si_errno=%d si_code=%d",
+            info->si_signo, info->si_errno, info->si_code);
+@@ -1912,7 +1912,7 @@
+ /* specific precise single step test */
+ void sig_trap_handler(int sig, siginfo_t *info, void *puc)
+ {
+-    struct ucontext *uc = puc;
++    ucontext_t *uc = puc;
+     printf("EIP=" FMTLX "\n", (long)uc->uc_mcontext.gregs[REG_EIP]);
+ }
+ 
+diff -Naur qemu-2.5.1/user-exec.c qemu-2.5.1_patched/user-exec.c
+--- qemu-2.5.1/user-exec.c	2016-03-29 23:01:23.000000000 +0200
++++ qemu-2.5.1_patched/user-exec.c	2017-09-29 18:17:27.796178245 +0200
+@@ -58,7 +58,7 @@
+ void cpu_resume_from_signal(CPUState *cpu, void *puc)
+ {
+ #ifdef __linux__
+-    struct ucontext *uc = puc;
++    ucontext_t *uc = puc;
+ #elif defined(__OpenBSD__)
+     struct sigcontext *uc = puc;
+ #endif
+@@ -172,7 +172,7 @@
+ #elif defined(__OpenBSD__)
+     struct sigcontext *uc = puc;
+ #else
+-    struct ucontext *uc = puc;
++    ucontext_t *uc = puc;
+ #endif
+     unsigned long pc;
+     int trapno;
+@@ -227,7 +227,7 @@
+ #elif defined(__OpenBSD__)
+     struct sigcontext *uc = puc;
+ #else
+-    struct ucontext *uc = puc;
++    ucontext_t *uc = puc;
+ #endif
+ 
+     pc = PC_sig(uc);
+@@ -289,7 +289,7 @@
+ 
+ #ifdef __APPLE__
+ #include <sys/ucontext.h>
+-typedef struct ucontext SIGCONTEXT;
++typedef ucontext_t SIGCONTEXT;
+ /* All Registers access - only for local access */
+ #define REG_sig(reg_name, context)              \
+     ((context)->uc_mcontext->ss.reg_name)
+@@ -332,7 +332,7 @@
+ #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+     ucontext_t *uc = puc;
+ #else
+-    struct ucontext *uc = puc;
++    ucontext_t *uc = puc;
+ #endif
+     unsigned long pc;
+     int is_write;
+@@ -359,7 +359,7 @@
+                            void *puc)
+ {
+     siginfo_t *info = pinfo;
+-    struct ucontext *uc = puc;
++    ucontext_t *uc = puc;
+     uint32_t *pc = uc->uc_mcontext.sc_pc;
+     uint32_t insn = *pc;
+     int is_write = 0;
+@@ -457,7 +457,7 @@
+ #if defined(__NetBSD__)
+     ucontext_t *uc = puc;
+ #else
+-    struct ucontext *uc = puc;
++    ucontext_t *uc = puc;
+ #endif
+     unsigned long pc;
+     int is_write;
+@@ -484,7 +484,7 @@
+ int cpu_signal_handler(int host_signum, void *pinfo, void *puc)
+ {
+     siginfo_t *info = pinfo;
+-    struct ucontext *uc = puc;
++    ucontext_t *uc = puc;
+     uintptr_t pc = uc->uc_mcontext.pc;
+     uint32_t insn = *(uint32_t *)pc;
+     bool is_write;
+@@ -513,7 +513,7 @@
+                        void *puc)
+ {
+     siginfo_t *info = pinfo;
+-    struct ucontext *uc = puc;
++    ucontext_t *uc = puc;
+     unsigned long pc;
+     int is_write;
+ 
+@@ -535,7 +535,7 @@
+ int cpu_signal_handler(int host_signum, void *pinfo, void *puc)
+ {
+     siginfo_t *info = pinfo;
+-    struct ucontext *uc = puc;
++    ucontext_t *uc = puc;
+     unsigned long ip;
+     int is_write = 0;
+ 
+@@ -566,7 +566,7 @@
+                        void *puc)
+ {
+     siginfo_t *info = pinfo;
+-    struct ucontext *uc = puc;
++    ucontext_t *uc = puc;
+     unsigned long pc;
+     uint16_t *pinsn;
+     int is_write = 0;
+@@ -619,7 +619,7 @@
+                        void *puc)
+ {
+     siginfo_t *info = pinfo;
+-    struct ucontext *uc = puc;
++    ucontext_t *uc = puc;
+     greg_t pc = uc->uc_mcontext.pc;
+     int is_write;
+ 
+@@ -635,7 +635,7 @@
+                        void *puc)
+ {
+     siginfo_t *info = pinfo;
+-    struct ucontext *uc = puc;
++    ucontext_t *uc = puc;
+     unsigned long pc = uc->uc_mcontext.sc_iaoq[0];
+     uint32_t insn = *(uint32_t *)pc;
+     int is_write = 0;


### PR DESCRIPTION
I fixed flask-socketio in requirements.txt to 2.9.1

I added  tracers/qemu.patch a small patch to enable qemu 2.5.1 to be compiled with new glibc.
I just replaced all references to `struct ucontext` with `ucontext_t`  as discussed in https://lists.gnu.org/archive/html/qemu-devel/2017-06/msg06508.html

With this patch qemu 2.5.1 can be compiled both with new and old glibc.

I tested on Archlinux with libc-2.26.so and Ubuntu 16.04.03 with libc-2.23.so
