### PR TITLE
flask.ext.socketio is deprecated, use flask_socketio instead.

### DIFF
--- a/extra/old_static/qira_static.py
+++ b/extra/old_static/qira_static.py
@@ -3,7 +3,7 @@ from qira_base import *
 import qira_config
 from qira_webserver import socket_method, socketio, app
 from flask import request
-from flask.ext.socketio import SocketIO, emit
+from flask_socketio import SocketIO, emit
 import os
 import sys
 import json

--- a/extra/servers/memory_server.py
+++ b/extra/servers/memory_server.py
@@ -1,6 +1,6 @@
 from qira_log import *
 from flask import Flask
-from flask.ext.socketio import SocketIO, emit
+from flask_socketio import SocketIO, emit
 import base64
 
 class Address:

--- a/middleware/qira_webserver.py
+++ b/middleware/qira_webserver.py
@@ -38,7 +38,7 @@ import qira_log
 LIMIT = 0
 
 from flask import Flask, Response, redirect, request
-from flask.ext.socketio import SocketIO, emit
+from flask_socketio import SocketIO, emit
 
 # http://stackoverflow.com/questions/8774958/keyerror-in-module-threading-after-a-successful-py-test-run
 import threading

--- a/middleware/qira_webserver.py
+++ b/middleware/qira_webserver.py
@@ -431,7 +431,7 @@ def run_server(largs, lprogram):
   print "****** starting WEB SERVER on %s:%d" % (qira_config.HOST, qira_config.WEB_PORT)
   threading.Thread(target=mwpoller).start()
   try:
-    socketio.run(app, host=qira_config.HOST, port=qira_config.WEB_PORT, log=open("/dev/null", "w"))
+    socketio.run(app, host=qira_config.HOST, port=qira_config.WEB_PORT, log_output=None)
   except KeyboardInterrupt:
     print "*** User raised KeyboardInterrupt"
     exit()

--- a/middleware/qira_webstatic.py
+++ b/middleware/qira_webstatic.py
@@ -9,7 +9,7 @@ from qira_webserver import socket_method
 from qira_webserver import app
 
 from flask import Flask, Response, redirect, request
-from flask.ext.socketio import SocketIO, emit
+from flask_socketio import SocketIO, emit
 
 from qira_base import *
 import json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pip
 six
 html
-flask-socketio==2.9.1
+flask-socketio
 pillow
 pyelftools
 socketIO-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pip
 six
 html
-flask-socketio
+flask-socketio==2.9.1
 pillow
 pyelftools
 socketIO-client


### PR DESCRIPTION
- fixed #192 
- fixed `flask.ext.socketio is deprecated, use flask_socketio instead.`