### PR TITLE
Fixes Ctrl+C and Cmd+C copying

### DIFF
--- a/web/client/controls.js
+++ b/web/client/controls.js
@@ -131,7 +131,7 @@ Session.setDefault("flat", false);
 
 // keyboard shortcuts
 window.onkeydown = function(e) {
-  if (!$(e.target).is("input")) e.preventDefault();
+  if (!$(e.target).is("input") && !((e.ctrlKey || e.metaKey) && e.keyCode === 67)) e.preventDefault();
   //p(e.keyCode);
   //p(e);
   if (e.ctrlKey == true) return;


### PR DESCRIPTION
Note: In cases when something is automatically highlighted (using highlight.js) that text is actually not a selection so you'll need to click + drag with the mouse to make a real selection to copy.