### PR TITLE
Use QEMU version 3.1.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN git clone https://github.com/geohot/qira.git --depth=1
 WORKDIR /qira
 
 # build qemu
-RUN apt-get -y install pkg-config zlib1g-dev libglib2.0-dev libpixman-1-dev
+RUN apt-get -y install pkg-config zlib1g-dev libglib2.0-dev libpixman-1-dev libcapstone-dev
 RUN cd tracers && ./qemu_build.sh
 
 # install python packages and link qira

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 # install system deps
 if [ $(which apt-get) ]; then
   echo "installing deps for ubuntu"
-  sudo apt-get -y install git curl python python-virtualenv python-dev build-essential pkg-config zlib1g-dev libglib2.0-dev libpixman-1-dev
+  sudo apt-get -y install git curl python python-virtualenv python-dev build-essential pkg-config zlib1g-dev libglib2.0-dev libpixman-1-dev libcapstone-dev
 else
   echo "*** You'll need to install Ubuntu or get a working build env for qemu and python yourself ***"
 fi

--- a/tracers/qemu_build.sh
+++ b/tracers/qemu_build.sh
@@ -2,11 +2,11 @@
 
 if [ ! -d qemu/qemu ]; then
   cd qemu
-  git clone https://github.com/geohot/qemu.git --depth 1 --branch qira
+  git clone https://github.com/geohot/qemu.git --depth 1 --branch v3.1.0-qira
   cd ..
 fi
 
 cd qemu/qemu
-./configure --target-list=i386-linux-user,x86_64-linux-user,arm-linux-user,ppc-linux-user,aarch64-linux-user,mips-linux-user,mipsel-linux-user --enable-tcg-interpreter --enable-debug-tcg --cpu=unknown --python=python
+./configure --target-list=i386-linux-user,x86_64-linux-user,arm-linux-user,ppc-linux-user,aarch64-linux-user,mips-linux-user,mipsel-linux-user --enable-tcg-interpreter --enable-debug-tcg --enable-capstone --cpu=unknown --python=python
 make -j
 

--- a/tracers/qemu_build.sh
+++ b/tracers/qemu_build.sh
@@ -7,6 +7,6 @@ if [ ! -d qemu/qemu ]; then
 fi
 
 cd qemu/qemu
-./configure --target-list=i386-linux-user,x86_64-linux-user,arm-linux-user,ppc-linux-user,aarch64-linux-user,mips-linux-user,mipsel-linux-user --enable-tcg-interpreter --enable-debug-tcg --enable-capstone --cpu=unknown --python=python
+./configure --target-list=i386-linux-user,x86_64-linux-user,arm-linux-user,ppc-linux-user,aarch64-linux-user,mips-linux-user,mipsel-linux-user --enable-tcg-interpreter --enable-debug-tcg --enable-capstone --python=python
 make -j
 


### PR DESCRIPTION
# Summary
This PR updates Qira's build scripts to support building QEMU version 3.1.0 for that tracer.

# Notes
**Warning**: Until [the related QEMU patch PR](https://github.com/geohot/qemu/pull/1) is merged in, this will break the QEMU build script.

The `tracers/qemu_build.sh` script assumes that the appropriately patched QEMU source code can be found on GitHub at `geohot/qemu`, branch `v3.1.0-qira`.