### PR TITLE
fix qemu build in docker, add 32bit gcc support to docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:16.04
 
 # system basics
-RUN apt-get update
-RUN apt-get -y install build-essential git curl python python-virtualenv python-dev
+RUN apt-get update && apt-get -y install build-essential gcc-multilib g++-multilib lib32z1 git curl python python-virtualenv python-dev
 
 # qemu deps
 RUN apt-get -y install pkg-config zlib1g-dev libglib2.0-dev libpixman-1-dev

--- a/tracers/qemu_build.sh
+++ b/tracers/qemu_build.sh
@@ -8,5 +8,4 @@ fi
 
 cd qemu/qemu
 ./configure --target-list=i386-linux-user,x86_64-linux-user,arm-linux-user,ppc-linux-user,aarch64-linux-user,mips-linux-user,mipsel-linux-user --enable-tcg-interpreter --enable-debug-tcg --cpu=unknown --python=python
-make -j
-
+make -j$(getconf _NPROCESSORS_ONLN) 


### PR DESCRIPTION
Building QEMU with make -j bombs my docker. Get core count on Linux/macOS using getconf _NPROCESSORS_ONLN

Add 32bit gcc support to docker.
