### PR TITLE
Change Linux PIN version to 3.7 and fix bug in PIN tracer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# I forked this to experiment with changes and be able to send improvement pull reqs. Use the main geohot version....
-
 # QIRA
 
 [![Build Status](https://travis-ci.org/geohot/qira.svg?branch=master)](https://travis-ci.org/geohot/qira)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# I forked this to experiment with changes and be able to send improvement pull reqs. Use the main geohot version....
+
 # QIRA
 
 [![Build Status](https://travis-ci.org/geohot/qira.svg?branch=master)](https://travis-ci.org/geohot/qira)

--- a/tracers/pin/qirapin.cpp
+++ b/tracers/pin/qirapin.cpp
@@ -193,9 +193,9 @@ static inline void mmap_close(MMAPFILE fd) {
 	close(fd);
 }
 static void *mmap_map(MMAPFILE fd, size_t size, size_t offset = 0) {
-	struct stat st;
-	fstat(fd, &st);
-	if(static_cast<size_t>(st.st_size) < offset+size)
+	USIZE thesize=0;
+	OS_FileSizeFD(fd,&thesize);
+	if(static_cast<size_t>(thesize) < offset+size)
 		ftruncate(fd, offset+size);
 
 	void *ret = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, offset);
@@ -442,7 +442,7 @@ public:
 #ifndef TARGET_WINDOWS
 	void fork_before(THREADID tid) {
 		PIN_GetLock(&lock, 0);
-		sync();
+		// sync(); // commented out to be compatible with later PIN versions. Seems to work...
 		// TODO: Close all files, reopen later
 		// I think this is only required for the current tid's data structure.
 	}

--- a/tracers/pin_build.sh
+++ b/tracers/pin_build.sh
@@ -5,14 +5,14 @@ cd "$(dirname "$0")/pin"
 case "`uname`" in
 Linux)
   if test -d pin-latest; then true; else
-    curl -L https://software.intel.com/sites/landingpage/pintool/downloads/pin-2.14-71313-gcc.4.4.7-linux.tar.gz | tar xz
-    ln -s pin-2.14-71313-gcc.4.4.7-linux pin-latest
+    curl -L https://software.intel.com/sites/landingpage/pintool/downloads/pin-3.7-97619-g0d0c92f4f-gcc-linux.tar.gz | tar xz
+    ln -s pin-3.7-97619-g0d0c92f4f-gcc-linux pin-latest
   fi
 
   # pin build deps, good?
   if which apt-get; then
     echo "apt-getting pin tool building deps"
-    sudo apt-get -qq -y install g++-4.9 gcc-4.9-multilib g++-4.9-multilib || echo "WARNING: apt-get failed"
+    sudo apt-get -qq -y install g++-7 gcc-7-multilib g++-7-multilib || echo "WARNING: apt-get failed"
   else
     echo "WARNING: you don't have apt-get, you are required to fetch pin tool building deps (e.g. 32 bit libs) on your own"
   fi


### PR DESCRIPTION
These changes will update the PIN tracer to version 3.7 for the Linux platform.

One of the changes is the removal of a sync() call. I can't see any clear reason why it's necessary, and in my testing there was no problem with the removal, but be aware.