### PR TITLE
[qira_program] fix strace parsing 

### DIFF
--- a/middleware/qira_program.py
+++ b/middleware/qira_program.py
@@ -465,7 +465,7 @@ class Trace:
       try:
         return_code = int(sc.split(") = ")[1].split(" ")[0], 0)
         fxn = sc.split("(")[0]
-        if fxn == "open" and return_code != -1:
+        if (fxn == "open" or fxn == "openat") and return_code != -1:
           firststr = sc.split('\"')[1]
           files[return_code] = firststr
         elif fxn[0:4] == "mmap":


### PR DESCRIPTION
glibc now uses `openat` for shared libs
```
cat /tmp/qira_logs/1_strace | grep -E "(open|mmap)"
...
0 36783 openat(-100,"/lib/x86_64-linux-gnu/libc.so.6",O_RDONLY|O_CLOEXEC) = 30
0 36783 mmap(NULL,8192,PROT_READ|PROT_WRITE,MAP_PRIVATE|MAP_ANONYMOUS,-1,0) = 0x7f0211181000
0 36783 mmap(NULL,1852680,PROT_READ,MAP_PRIVATE|MAP_DENYWRITE,30,0) = 0x7f0211183000
...
```
This PR fixes `base_memory` for shared libs
