### PR TITLE
Add instructions for Docker installation and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <pre>
 Ubuntu 14.04 and 16.04 supported out of the box.
-18.04 is having a problem with building QEMU
+18.04 and 20.x is having a problem with building QEMU
 See forked QEMU source at https://github.com/geohot/qemu/tree/qira to fix.
 
 Non Linux hosts may run the rest of QIRA, but cannot run the QEMU tracer.
@@ -31,6 +31,24 @@ git clone https://github.com/geohot/qira.git
 cd qira/
 ./install.sh
 </pre>
+
+### Docker
+<pre>
+cd ~/
+git clone https://github.com/geohot/qira.git
+cd qira/docker
+./build.sh
+</pre>
+
+Run:
+<pre>
+sudo docker run -p 3302:3302 -it qira bash
+qira _executable_file_
+</pre>
+
+Then, connect to _localhost:3002_
+
+If you want to copy a file from your filesystem to the container launch: <pre>sudo docker cp _source_ _container_name_:_path_ </pre>
 
 ## Installation Extras
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ cd qira/docker
 ./build.sh
 </pre>
 
-Run: <pre> 	sudo docker run -p 3302:3302 -it qira bash
-		qira _target_ </pre>
+Run: <pre> sudo docker run -p 3302:3302 -it qira bash
+qira _target_ </pre>
 
 Then, connect to __localhost:3002__
 

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ cd qira/docker
 Run:
 <pre>
 sudo docker run -p 3302:3302 -it qira bash
-qira _executable_file_
+qira _exec_
 </pre>
 
-Then, connect to _localhost:3002_
+Then, connect to __localhost:3002__
 
 If you want to copy a file from your filesystem to the container launch: <pre>sudo docker cp _source_ _container_name_:_path_ </pre>
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ cd qira/docker
 Run:
 <pre>
 sudo docker run -p 3302:3302 -it qira bash
-qira _exec_
+qira _target_
 </pre>
 
 Then, connect to __localhost:3002__

--- a/README.md
+++ b/README.md
@@ -40,11 +40,8 @@ cd qira/docker
 ./build.sh
 </pre>
 
-Run:
-<pre>
-sudo docker run -p 3302:3302 -it qira bash
-qira _target_
-</pre>
+Run: <pre> 	sudo docker run -p 3302:3302 -it qira bash
+		qira _target_ </pre>
 
 Then, connect to __localhost:3002__
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ cd qira/docker
 ./build.sh
 </pre>
 
-Run: <pre> sudo docker run -p 3302:3302 -it qira bash
-qira _target_ </pre>
+Run: <pre>sudo docker run -p 3302:3302 -it qira bash
+qira _target_</pre>
 
 Then, connect to __localhost:3002__
 


### PR DESCRIPTION
GeoHot's Qemu doesn't build on Ubuntu 20.x, but installation through Docker works well
So, more info about Docker installation and usage are needed